### PR TITLE
updated CI integration to reflect new flake-pure functionality

### DIFF
--- a/ci.nix
+++ b/ci.nix
@@ -1,3 +1,0 @@
-if builtins?getFlake
-then (builtins.getFlake (toString ./.)).ciNix
-else (import ./flake-compat.nix).defaultNix.ciNix

--- a/flake.lock
+++ b/flake.lock
@@ -217,37 +217,6 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat-ci": {
-      "locked": {
-        "lastModified": 1641672839,
-        "narHash": "sha256-Bdwv+DKeEMlRNPDpZxSz0sSrqQBvdKO5fZ8LmvrgCOU=",
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "rev": "e832114bc18376c0f3fa13c19bf5ff253cc6570a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-compat-ci",
-        "type": "github"
-      }
-    },
     "flake-utils": {
       "locked": {
         "lastModified": 1623875721,
@@ -839,11 +808,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1646331602,
-        "narHash": "sha256-cRuytTfel52z947yKfJcZU7zbQBgM16qqTf+oJkVwtg=",
+        "lastModified": 1648097358,
+        "narHash": "sha256-GMoTKP/po2Nbkh1tvPvP8Ww6NyFW8FFst1Z3nfzffZc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ad267cc9cf3d5a6ae63940df31eb31382d6356e6",
+        "rev": "4d60081494259c0785f7e228518fee74e0792c1b",
         "type": "github"
       },
       "original": {
@@ -1045,8 +1014,6 @@
     },
     "root": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-compat-ci": "flake-compat-ci",
         "nixpkgs": "nixpkgs",
         "uplc2c": "uplc2c"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,25 +4,15 @@
   inputs =
   {
     uplc2c.url = "path:./compiler";
-
-    #CI integration
-    flake-compat-ci.url = "github:hercules-ci/flake-compat-ci";
-    flake-compat = {
-      url = "github:edolstra/flake-compat";
-      flake = false;
-    };
   };
-  outputs = { self, nixpkgs, uplc2c, flake-compat, flake-compat-ci }:
+  outputs = { self, nixpkgs, uplc2c }:
   {
     packages.x86_64-linux = let pkgs = import nixpkgs { system = "x86_64-linux"; };
     in {
-     architecture = pkgs.callPackage ./architecture/default.nix {};
+      architecture = pkgs.callPackage ./architecture/default.nix {};
      };
 
-     ciNix = flake-compat-ci.lib.recurseIntoFlakeWith {
-           flake = self;
-           systems = [ "x86_64-linux" ];
-         };
+     herculesCI.ciSystems = [ "x86_64-linux" ];
      defaultPackage.x86_64-linux = uplc2c.defaultPackage.x86_64-linux;
   };
 }


### PR DESCRIPTION
As our instance of Hercules has been updated, we no longer require the ci-compat shim to build using flakes.
Given native support of our functional pipeline, I am removing the ci-compat throughout our repositories.